### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Deploy blog 🚀
 on: [push]
+permissions:
+  contents: read
 jobs:
   Deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KS-OTO/blog/security/code-scanning/1](https://github.com/KS-OTO/blog/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow:
- `contents: read` is required to access the repository contents.
- Additional permissions are not explicitly required for the steps shown, as they rely on external tools and secrets rather than GitHub-specific features.

The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
